### PR TITLE
Added namespace to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "autoload": {
     "psr-0": {
-      "": "src/"
+      "Amp": "src/"
     }
   }
 }


### PR DESCRIPTION
I'm aware that you prefer your own autoloader, but it would nice for other people using Composer based autoloaders for this to set 'correctly'. Either should work, it's just that the Composer autoloader sticks blank namespaces together in a 'fallback' list which works but isn't optimal.
