### PR TITLE
Fix worker flag

### DIFF
--- a/lib/Dispatcher.php
+++ b/lib/Dispatcher.php
@@ -218,7 +218,7 @@ class Dispatcher {
         $resultCodes = new SharedData;
         $thread = new Thread($results, $resultCodes, $this->ipcUri);
 
-        if (!$thread->start()) {
+        if (!$thread->start($this->threadStartFlags)) {
             throw new \RuntimeException(
                 'Worker thread failed to start'
             );


### PR DESCRIPTION
Currently when you do `$dispatcher->setOption(Dispatcher::OPT_THREAD_FLAGS, PTHREADS_INHERIT_NONE);` He start worker without passing flag ... And I need to do not inherit because i'm using composer with file-map wich scream because of re importing functions.

I sended against your current upgrade branch
